### PR TITLE
Pin EVM version to Shanghai

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 solc = "0.8.18"
+evm_version = "shanghai"
 
 [rpc_endpoints]
 local-c = "http://localhost:9650/ext/bc/C/rpc"


### PR DESCRIPTION
Teleporter v1.0.4 upgrades to solc version 0.8.25, which supports opcodes specified in Ethereum's Cancun upgrade, which are [not yet supported](https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/131-cancun-eips) on Avalanche EVM chains. We maintain compatibilty by independently specifying the solc and evm versions in the foundry project.

This PR explicitly specifies the evm version here, allowing Teleporter v1.0.4 to be used. Without it, transactions revert due to the missing `MCOPY` opcode.