### PR TITLE
Improve Codespace Load Times

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,10 @@
-FROM avaplatform/avalanche-cli:v1.7.1 as avalanche-cli
-FROM avaplatform/awm-relayer:latest as awm-relayer
-FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:latest as foundry
+FROM avaplatform/avalanche-cli:latest AS avalanche-cli
+FROM avaplatform/awm-relayer:latest AS awm-relayer
+FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:latest AS foundry
 FROM mcr.microsoft.com/devcontainers/base
 
 COPY --from=avalanche-cli /avalanche /usr/local/bin/avalanche
-
 COPY --from=awm-relayer /usr/bin/awm-relayer /usr/local/bin/awm-relayer
-
 COPY --from=foundry /usr/local/bin/forge /usr/local/bin/forge
 COPY --from=foundry /usr/local/bin/cast /usr/local/bin/cast
 COPY --from=foundry /usr/local/bin/anvil /usr/local/bin/anvil
@@ -15,3 +13,43 @@ COPY --from=foundry /usr/local/bin/chisel /usr/local/bin/chisel
 RUN mkdir -p /home/vscode/.foundry/bin
 COPY --from=foundry /usr/local/bin/forge /home/vscode/.foundry/bin/forge
 
+# Switch to root user to install system packages
+USER root
+
+# Install Git and other dependencies
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Ensure vscode owns its home directory
+RUN chown -R vscode:vscode /home/vscode
+
+# Set HOME environment variable
+ENV HOME=/home/vscode
+
+# Switch back to vscode user
+USER vscode
+
+# Install nvm, Node.js, and TypeScript
+ENV NVM_DIR=/home/vscode/.nvm
+ENV NODE_VERSION=23.0.0
+
+# Install nvm and Node.js
+RUN mkdir -p $NVM_DIR \
+    && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.1/install.sh | bash \
+    && . $NVM_DIR/nvm.sh \
+    && nvm install $NODE_VERSION \
+    && nvm alias default $NODE_VERSION
+
+# Update PATH for nvm and Node.js
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# Install TypeScript globally
+RUN npm install -g typescript
+
+# Ensure Node.js and npm are accessible in future shells
+RUN echo 'export NVM_DIR="$HOME/.nvm"' >> $HOME/.bashrc \
+    && echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $HOME/.bashrc \
+    && echo 'export PATH="$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"' >> $HOME/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM avaplatform/avalanche-cli:latest AS avalanche-cli
+FROM avaplatform/avalanche-cli:v1.7.1 AS avalanche-cli
 FROM avaplatform/awm-relayer:latest AS awm-relayer
 FROM --platform=linux/amd64 ghcr.io/foundry-rs/foundry:latest AS foundry
 FROM mcr.microsoft.com/devcontainers/base

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,8 +16,13 @@
 		"C_CHAIN_BLOCKCHAIN_ID_HEX": "0x31233cae135e3974afa396e90f465aa28027de5f97f729238c310d2ed2f71902",
 		"PK_43113": "56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027"
 	},
-	"postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git submodule update --init --recursive",
-	"postStartCommand": "git submodule update --recursive && avalanche config metrics enable",
+	"postCreateCommand": {
+		"init-git-submodules": "git config --global --add safe.directory ${containerWorkspaceFolder} && git submodule update --init --recursive"
+	},
+	"postStartCommand": {
+		"update-git-submodules": "git submodule update --recursive",
+		"enable-avalanche-cli-metrics": "avalanche config metrics enable"
+	},
 	"forwardPorts": [
 		3000,
 		9650,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
 	"name": "Avalanche Starter Kit",
-	"build": {
-		"dockerfile": "Dockerfile"
-	},
+	"image": "owenwahlgren/avalanche-starter-kit",
 	"runArgs": [
 		"--network=host"
 	],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
 	"name": "Avalanche Starter Kit",
-	"image": "owenwahlgren/avalanche-starter-kit",
+	"image": "ghcr.io/owenwahlgren/avalanche-starter-kit",
 	"runArgs": [
 		"--network=host"
 	],

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,12 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
 	"name": "Avalanche Starter Kit",
-	"image": "ghcr.io/owenwahlgren/avalanche-starter-kit:latest",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
 	"runArgs": [
 		"--network=host"
 	],
-	"remoteUser": "vscode",
 	"remoteEnv": {
 		"PATH": "${containerEnv:PATH}:/usr/local/bin/",
 		"PK": "56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,13 +5,7 @@
 	"runArgs": [
 		"--network=host"
 	],
-	"features": {
-		"ghcr.io/devcontainers-community/npm-features/typescript": {},
-		"ghcr.io/devcontainers/features/node:1": {
-			"version": "lts",
-			"installYarn": true
-		}
-	},
+	"remoteUser": "vscode",
 	"remoteEnv": {
 		"PATH": "${containerEnv:PATH}:/usr/local/bin/",
 		"PK": "56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027",
@@ -22,13 +16,8 @@
 		"C_CHAIN_BLOCKCHAIN_ID_HEX": "0x31233cae135e3974afa396e90f465aa28027de5f97f729238c310d2ed2f71902",
 		"PK_43113": "56289e99c94b6912bfc12adc093c9b51124f0dc54ac7a766b2bc5ccf558d8027"
 	},
-	"postCreateCommand": {
-		"init-git-submodules": "git config --global --add safe.directory ${containerWorkspaceFolder} && git submodule update --init --recursive"
-	},
-	"postStartCommand": {
-		"update-git-submodules": "git submodule update --recursive",
-		"enable-avalanche-cli-metrics": "avalanche config metrics enable"
-	},
+	"postCreateCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git submodule update --init --recursive",
+	"postStartCommand": "git submodule update --recursive && avalanche config metrics enable",
 	"forwardPorts": [
 		3000,
 		9650,

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/devcontainer.json.
 {
 	"name": "Avalanche Starter Kit",
-	"image": "ghcr.io/owenwahlgren/avalanche-starter-kit",
+	"image": "ghcr.io/owenwahlgren/avalanche-starter-kit:latest",
 	"runArgs": [
 		"--network=host"
 	],


### PR DESCRIPTION
- Move the Dockerfile to a hosted image instead of building it from within the Codespace.
- Migrate the "features" section for `devcontainer.json` directly into the Docker image (large load time improvement).
Load times improved from average ~5 minutes -> ~2 minutes

https://ghcr.io/owenwahlgren/avalanche-starter-kit 
(I don't think moving the image to a host improves load time... the big improvement is from moving the "features" directly into the image. Maybe we should keep the Dockerfile in the repo to avoid confusion)
