### PR TITLE
Fix stale TeleporterRegistry import path (teleporter/upgrades -> teleporter/registry)

### DIFF
--- a/contracts/interchain-messaging/registry/ReceiverOnSubnetWithRegistry.sol
+++ b/contracts/interchain-messaging/registry/ReceiverOnSubnetWithRegistry.sol
@@ -5,7 +5,7 @@
 
 pragma solidity ^0.8.18;
 
-import "@teleporter/upgrades/TeleporterRegistry.sol";
+import "@teleporter/registry/TeleporterRegistry.sol";
 import "@teleporter/ITeleporterMessenger.sol";
 import "@teleporter/ITeleporterReceiver.sol";
 

--- a/contracts/interchain-messaging/registry/SenderOnCChainWithRegistry.sol
+++ b/contracts/interchain-messaging/registry/SenderOnCChainWithRegistry.sol
@@ -5,7 +5,7 @@
 
 pragma solidity ^0.8.18;
 
-import "@teleporter/upgrades/TeleporterRegistry.sol";
+import "@teleporter/registry/TeleporterRegistry.sol";
 import "@teleporter/ITeleporterMessenger.sol";
 
 contract SenderOnCChain {

--- a/contracts/misc/creating-contracts/BridgeReceiverOnSubnet.sol
+++ b/contracts/misc/creating-contracts/BridgeReceiverOnSubnet.sol
@@ -5,7 +5,7 @@
 
 pragma solidity ^0.8.18;
 
-import "@teleporter/upgrades/TeleporterRegistry.sol";
+import "@teleporter/registry/TeleporterRegistry.sol";
 import "@teleporter/ITeleporterMessenger.sol";
 import "@teleporter/ITeleporterReceiver.sol";
 import "./MyERC20Token.sol";

--- a/contracts/misc/creating-contracts/BridgeSenderOnCChain.sol
+++ b/contracts/misc/creating-contracts/BridgeSenderOnCChain.sol
@@ -5,7 +5,7 @@
 
 pragma solidity ^0.8.18;
 
-import "@teleporter/upgrades/TeleporterRegistry.sol";
+import "@teleporter/registry/TeleporterRegistry.sol";
 import "@teleporter/ITeleporterMessenger.sol";
 import "./BridgeActions.sol";
 


### PR DESCRIPTION
## Summary
`icm-contracts` renamed `contracts/teleporter/upgrades/` to `contracts/teleporter/registry/` in July 2024 ([ava-labs/icm-contracts@1488a35](https://github.com/ava-labs/icm-contracts/commit/1488a35505be69a1d4ebc63b22b4b36a971a8e9f)). Four example contracts in this repo still import the old path, so a clean clone + `git submodule update --init --recursive` + `forge build` fails with:

```
Error (6275): Source "lib/icm-contracts/contracts/teleporter/upgrades/TeleporterRegistry.sol" not found
```

This updates the import path in the 4 affected files. `TeleporterRegistry`'s public API used by these examples (`getLatestTeleporter()`, `getVersionFromAddress()`) is unchanged at the new location, so this is a pure path fix — no other code changes needed.

Files fixed:
- `contracts/interchain-messaging/registry/ReceiverOnSubnetWithRegistry.sol`
- `contracts/interchain-messaging/registry/SenderOnCChainWithRegistry.sol`
- `contracts/misc/creating-contracts/BridgeReceiverOnSubnet.sol`
- `contracts/misc/creating-contracts/BridgeSenderOnCChain.sol`

Note: `contracts/misc/erc721-bridge/ERC721Bridge.sol` (+ its test) has a related but separate issue — it inherits `TeleporterOwnerUpgradeable`, which was removed entirely from `icm-contracts` (replaced by `TeleporterRegistryOwnableApp` with a different API). That's a real port, not a path fix, so it's out of scope here; happy to follow up in a separate PR if useful.

## Test plan
- [x] `git submodule update --init --recursive`
- [x] `forge build` — all 4 fixed files compile successfully (verified via `forge build --skip "*ERC721Bridge*"` to isolate from the unrelated, still-broken ERC721Bridge example)

🤖 Generated with [Claude Code](https://claude.com/claude-code)